### PR TITLE
Fix multiple definitions of _cstd_seed, make sure it is declared once…

### DIFF
--- a/cstd.h
+++ b/cstd.h
@@ -64,7 +64,12 @@ static inline uint64_t get_maxrss(void) { struct rusage x; return getrusage(RUSA
 static inline uint64_t atoul (char *s) { return strtoul(s,0,10); }
 
 // this function should be used by anyone wanting a seed for a random number generator; when debugging you can fix _cstd_seed to get deterministic behavior
+#ifdef CSTD_ONCE
 unsigned long _cstd_seed;       // you can set this to any non-zero value (in your main function, not here)
+#else
+extern unsigned long _cstd_seed;
+#endif
+
 static inline unsigned long cstd_seed(void)
 {
     if ( ! _cstd_seed ) {

--- a/makefile
+++ b/makefile
@@ -4,4 +4,4 @@ clean:
 	rm -vf zcubes
 
 zcubes: zcubes.c admissible.c primes.c invtab.c mem.c admissible.h cbrts.h primes.h mem.h invtab.h kdata.h zcheck.h report.h m64.h b32.h bitmap.h cstd.h
-	gcc -pedantic -Wall -O2 -march=nehalem -o zcubes admissible.c zcubes.c invtab.c primes.c mem.c -lprimesieve -lgmp -lm -lpthread
+	gcc -pedantic -Wall -O3 -march=native -o zcubes admissible.c zcubes.c invtab.c primes.c mem.c -lprimesieve -lgmp -lpthread -lm

--- a/zcubes.c
+++ b/zcubes.c
@@ -12,6 +12,7 @@
 #include "m64.h"                    // 64-bit Montgomery arithmetic
 #include "b32.h"                    // 32-bit Barrett arithmetic (including functions for fast CRT-ing)
 #include "bitmap.h"                 // simple bitmap test/set/lookup and enumeration
+#define CSTD_ONCE
 #include "cstd.h"                   // define SOFTASSERTS before this inlude if you want them on
 #include "report.h"                 // reporting and output functions
 #include "kdata.h"                  // loads cubic-reciprocity constraints for k, precomputes admissible d|k


### PR DESCRIPTION
…, and made extern otherwise

Change -march flag to native, and increase optimization to -O3

This fixes compilation for gcc (Ubuntu 10.2.0-13ubuntu1) 10.2.0 , where I would get this error:

make
gcc -pedantic -Wall -O3 -march=native -o zcubes admissible.c zcubes.c invtab.c primes.c mem.c -lprimesieve -lgmp -lpthread -lm
/usr/bin/ld: /tmp/ccRiLFxL.o:(.bss+0x0): multiple definition of `_cstd_seed'; /tmp/ccIbPkmL.o:(.bss+0x10): first defined here
/usr/bin/ld: /tmp/ccM67w8I.o:(.bss+0x0): multiple definition of `_cstd_seed'; /tmp/ccIbPkmL.o:(.bss+0x10): first defined here
collect2: error: ld returned 1 exit status
